### PR TITLE
Refactor bit collector

### DIFF
--- a/test/BaseClass.cpp
+++ b/test/BaseClass.cpp
@@ -2,4 +2,9 @@
 #define LiquidCrystal_Test LiquidCrystal_Base
 #include "Common.cpp"
 
+unittest(testingClassName) {
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  assertEqual("LiquidCrystal_Base", lcd.className());
+}
+
 unittest_main()

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -19,20 +19,24 @@ const byte d5 = 15;
 const byte d6 = 16;
 const byte d7 = 17;
 
-GodmodeState *state = GODMODE();
-
 class BitCollector : public DataStreamObserver {
 private:
   bool fourBitMode;
   bool showData;
   vector<int> pinLog;
+  GodmodeState *state;
 
 public:
   BitCollector(bool showData = false, bool fourBitMode = true)
       : DataStreamObserver(false, false) {
     this->fourBitMode = fourBitMode;
     this->showData = showData;
+    state = GODMODE();
+    state->reset();
+    state->digitalPin[enable].addObserver("lcd", this);
   }
+
+  ~BitCollector() { state->digitalPin[enable].removeObserver("lcd"); }
 
   virtual void onBit(bool aBit) {
     if (aBit) {
@@ -49,7 +53,7 @@ public:
       value = (value << 1) + state->digitalPin[d0];
       pinLog.push_back(value);
       if (showData) {
-        std::cout.width(7);
+        std::cout.width(5);
         std::cout << std::right << value << " : " << ((value >> 9) & 1) << "  "
                   << ((value >> 8) & 1) << "  ";
         if (fourBitMode) {
@@ -82,6 +86,7 @@ public:
   virtual String observerName() const { return "BitCollector"; }
 };
 
+// we don't look at the pins here, just verify that we can call the constructors
 unittest(constructors) {
   LiquidCrystal_Test lcd1(rs, enable, d4, d5, d6, d7);
   LiquidCrystal_Test lcd2(rs, rw, enable, d4, d5, d6, d7);
@@ -104,160 +109,153 @@ unittest(constructors) {
   delete lcd5;
 }
 
-unittest(init) {
-  state->reset();
-  BitCollector pinValues(false);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
-  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  state->digitalPin[enable].removeObserver("lcd");
-  /*     rs rw  d7 to d0
-     48 : 0  0  00110000      set to 8-bit mode (takes three tries)
-     48 : 0  0  00110000      set to 8-bit mode
-     48 : 0  0  00110000      set to 8-bit mode
-     32 : 0  0  00100000      set to 4-bit mode, 1 line, 8-bit font
-     32 : 0  0  0010          \
-      0 : 0  0      0000       set to 4-bit mode, 1 line, 8-bit font
-      0 : 0  0  0000          \
-    192 : 0  0      1100       display on, cursor off, blink off
-      0 : 0  0  0000          \
-    016 : 0  0      0001       clear display
-      0 : 0  0  0000          \
-     96 : 0  0      0110       increment cursor position, no display shift
-   */
-  vector<int> expected{48, 48, 48, 32, 32, 0, 0, 192, 0, 16, 0, 96};
-  assertTrue(pinValues.isEqualTo(expected));
-}
-
-unittest(begin_16_02) {
-  state->reset();
-  BitCollector pinValues(false);
-  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
-  lcd.begin(16, 2);
-  state->digitalPin[enable].removeObserver("lcd");
-  /*     rs rw  d7 to d0
-     48 : 0  0  00110000      set to 8-bit mode (takes three tries)
-     48 : 0  0  00110000      set to 8-bit mode
-     48 : 0  0  00110000      set to 8-bit mode
-     32 : 0  0  00100000      set to 4-bit mode, 1 line, 8-bit font
-     32 : 0  0  0010          \
-    128 : 0  0      1000       set to 4-bit mode, 2 lines, 8-bit font
-      0 : 0  0  0000          \
-    192 : 0  0      1100       display on, cursor off, blink off
-      0 : 0  0  0000          \
-    016 : 0  0      0001       clear display
-      0 : 0  0  0000          \
-     96 : 0  0      0110       increment cursor position, no display shift
-   */
-  vector<int> expected{48, 48, 48, 32, 32, 128, 0, 192, 0, 16, 0, 96};
-  assertTrue(pinValues.isEqualTo(expected));
-}
-
-unittest(createChar) {
-  byte smiley[8] = {
-      B00000, B10001, B00000, B00000, B10001, B01110, B00000,
-  };
-
-  // Test the function
-  state->reset();
-  BitCollector pinValues(false);
-  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
-  lcd.createChar(0, smiley);
-  state->digitalPin[enable].removeObserver("lcd");
-  /*     rs rw  d7 to d0
-     64 : 0  0  0100
-      0 : 0  0      0000
-    512 : 1  0  0000
-    512 : 1  0      0000
-    528 : 1  0  0001
-    528 : 1  0      0001
-    512 : 1  0  0000
-    512 : 1  0      0000
-    512 : 1  0  0000
-    512 : 1  0      0000
-    528 : 1  0  0001
-    528 : 1  0      0001
-    512 : 1  0  0000
-    736 : 1  0      1110
-    512 : 1  0  0000
-    512 : 1  0      0000
-    512 : 1  0  0000
-    512 : 1  0      0000
+/*     rs rw  d7 to d0
+   48 : 0  0  00110000      set to 8-bit mode (takes three tries)
+   48 : 0  0  00110000      set to 8-bit mode
+   48 : 0  0  00110000      set to 8-bit mode
+   32 : 0  0  00100000      set to 4-bit mode, 1 line, 8-bit font
+   32 : 0  0  0010          \
+    0 : 0  0      0000       set to 4-bit mode, 1 line, 8-bit font
+    0 : 0  0  0000          \
+  192 : 0  0      1100       display on, cursor off, blink off
+    0 : 0  0  0000          \
+  016 : 0  0      0001       clear display
+    0 : 0  0  0000          \
+   96 : 0  0      0110       increment cursor position, no display shift
 */
+unittest(init) {
+  vector<int> expected{48, 48, 48, 32, 32, 0, 0, 192, 0, 16, 0, 96};
+  BitCollector pinValues(false); // test the next line (a constructor)
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  assertTrue(pinValues.isEqualTo(expected));
+}
+
+/*     rs rw  d7 to d0
+   48 : 0  0  00110000      set to 8-bit mode (takes three tries)
+   48 : 0  0  00110000      set to 8-bit mode
+   48 : 0  0  00110000      set to 8-bit mode
+   32 : 0  0  00100000      set to 4-bit mode, 1 line, 8-bit font
+   32 : 0  0  0010          \
+  128 : 0  0      1000       set to 4-bit mode, 2 lines, 8-bit font
+    0 : 0  0  0000          \
+  192 : 0  0      1100       display on, cursor off, blink off
+    0 : 0  0  0000          \
+  016 : 0  0      0001       clear display
+    0 : 0  0  0000          \
+   96 : 0  0      0110       increment cursor position, no display shift
+*/
+unittest(begin) {
+  vector<int> expected{48, 48, 48, 32, 32, 128, 0, 192, 0, 16, 0, 96};
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  BitCollector pinValues(false); // test the next line
+  lcd.begin(16, 2);
+  assertTrue(pinValues.isEqualTo(expected));
+}
+
+/*     rs rw  d7 to d0
+   64 : 0  0  0100
+    0 : 0  0      0000
+  512 : 1  0  0000
+  512 : 1  0      0000
+  528 : 1  0  0001
+  528 : 1  0      0001
+  512 : 1  0  0000
+  512 : 1  0      0000
+  512 : 1  0  0000
+  512 : 1  0      0000
+  528 : 1  0  0001
+  528 : 1  0      0001
+  512 : 1  0  0000
+  736 : 1  0      1110
+  512 : 1  0  0000
+  512 : 1  0      0000
+  512 : 1  0  0000
+  512 : 1  0      0000
+*/
+unittest(createChar) {
   vector<int> expected{64,  0,   512, 512, 528, 528, 512, 512, 512,
                        512, 528, 528, 512, 736, 512, 512, 512, 512};
+  byte smiley[8] = {B00000, B10001, B00000, B00000, B10001, B01110, B00000};
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  BitCollector pinValues(false); // test the next line
+  lcd.createChar(0, smiley);
   assertTrue(pinValues.isEqualTo(expected));
 }
 
+/*     rs rw  d7 to d0
+    0 : 0  0  0000          \
+   16 : 0  0      0001       clear
+*/
 unittest(clear) {
-  state->reset();
-  BitCollector pinValues(false);
-  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  lcd.begin(16, 2);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
-  lcd.clear();
-  state->digitalPin[enable].removeObserver("lcd");
-  /*     rs rw  d7 to d0
-      0 : 0  0  0000          \
-     16 : 0  0      0001       clear
-   */
   vector<int> expected{0, 16};
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  lcd.begin(16, 2);
+  BitCollector pinValues(false); // test the next line
+  lcd.clear();
   assertTrue(pinValues.isEqualTo(expected));
 }
 
+/*      rs rw  d7 to d0
+    576 : 1  0  0100      \
+    640 : 1  0      1000  0x48 H
+    608 : 1  0  0110      \
+    592 : 1  0      0101  0x65 e
+    608 : 1  0  0110      \
+    704 : 1  0      1100  0x6C l
+    608 : 1  0  0110      \
+    704 : 1  0      1100  0x6C l
+    608 : 1  0  0110      \
+    752 : 1  0      1111  0x6F o
+*/
 unittest(print_hello) {
-  state->reset();
-  BitCollector pinValues(false);
-  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  lcd.begin(16, 2);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
-  lcd.print("Hello");
-  state->digitalPin[enable].removeObserver("lcd");
-  /*      rs rw  d7 to d0
-     576 : 1  0  0100      \
-     640 : 1  0      1000  0x48 H
-     608 : 1  0  0110      \
-     592 : 1  0      0101  0x65 e
-     608 : 1  0  0110      \
-     704 : 1  0      1100  0x6C l
-     608 : 1  0  0110      \
-     704 : 1  0      1100  0x6C l
-     608 : 1  0  0110      \
-     752 : 1  0      1111  0x6F o
-   */
   vector<int> expected{576, 640, 608, 592, 608, 704, 608, 704, 608, 752};
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  lcd.begin(16, 2);
+  BitCollector pinValues(false); // test the next line
+  lcd.print("Hello");
   assertTrue(pinValues.isEqualTo(expected));
 }
 
+/*     rs rw  d7 to d0
+   16 : 0  0  0001      \
+  128 : 0  0      1000   00011000 = shift display left
+*/
 unittest(scrollDisplayLeft) {
-  state->reset();
-  BitCollector pinValues(false);
+  vector<int> expected{16, 128};
   LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
   lcd.begin(16, 2);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
+  BitCollector pinValues(false); // test the next line
   lcd.scrollDisplayLeft();
-  state->digitalPin[enable].removeObserver("lcd");
-  /*     rs rw  d7 to d0
-     16 : 0  0  0001      \
-    128 : 0  0      1000   00011000 = shift display left
-   */
-  vector<int> expected{16, 128};
   assertTrue(pinValues.isEqualTo(expected));
 }
 
+/*     rs rw  d7 to d0
+   16 : 0  0  0001      first half of command
+  192 : 0  0      1100  full command: 00011100 = shift display right
+*/
 unittest(scrollDisplayRight) {
-  state->reset();
-  BitCollector pinValues(false);
+  vector<int> expected{16, 192};
   LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
   lcd.begin(16, 2);
-  state->digitalPin[enable].addObserver("lcd", &pinValues);
+  BitCollector pinValues(false); // test the next line
   lcd.scrollDisplayRight();
-  state->digitalPin[enable].removeObserver("lcd");
-  /*     rs rw  d7 to d0
-     16 : 0  0  0001      first half of command
-    192 : 0  0      1100  full command: 00011100 = shift display right
-   */
-  vector<int> expected{16, 192};
   assertTrue(pinValues.isEqualTo(expected));
+}
+
+unittest(failIfWrongSize) {
+  vector<int> expected{0};
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  lcd.begin(16, 2);
+  BitCollector pinValues(false); // test the next line
+  lcd.clear();
+  assertFalse(pinValues.isEqualTo(expected));
+}
+
+unittest(failIfWrongValues) {
+  vector<int> expected{0, 255};
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  lcd.begin(16, 2);
+  BitCollector pinValues(false); // test the next line
+  lcd.clear();
+  assertFalse(pinValues.isEqualTo(expected));
 }

--- a/test/TestClass.cpp
+++ b/test/TestClass.cpp
@@ -2,6 +2,11 @@
 #define LiquidCrystal_Test LiquidCrystal
 #include "Common.cpp"
 
+unittest(testingClassName) {
+  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
+  assertEqual("LiquidCrystal_CI", lcd.className());
+}
+
 unittest(getRows) {
   LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
   assertEqual(1, lcd.getRows());


### PR DESCRIPTION
With this change we no longer have a global array keeping the values but they are now stored in the BitCollector object as a vector (so variable length). We also have a comparison function in BitCollector so that each test doesn't have to do its own comparisons. Finally, we have an option to print the values (and a choice of 8-bit or 4-bit).