### PR TITLE
High level tests for cursor/noCursor

### DIFF
--- a/test/TestClass.cpp
+++ b/test/TestClass.cpp
@@ -213,13 +213,17 @@ unittest(blink_high) {
 unittest(cursor_high) {
   // create lcd object
   LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  // TODO
-}
+  
+  // assert startup no cursor is set
+  assertEqual(false, lcd.isCursor());
 
-unittest(noCursor_high) {
-  // create lcd object
-  LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  // TODO
+  // check cursor function
+  lcd.cursor();
+  assertEqual(true, lcd.isCursor());
+
+  // check noCursor function
+  lcd.noCursor();
+  assertEqual(false, lcd.isCursor());
 }
 
 unittest_main()

--- a/test/TestClass.cpp
+++ b/test/TestClass.cpp
@@ -210,8 +210,7 @@ unittest(blink_high) {
   assertEqual(0, blinking);
 }
 
-unittest(cursor_high)
-{
+unittest(cursor_high) {
   // create lcd object
   LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
 

--- a/test/TestClass.cpp
+++ b/test/TestClass.cpp
@@ -210,10 +210,11 @@ unittest(blink_high) {
   assertEqual(0, blinking);
 }
 
-unittest(cursor_high) {
+unittest(cursor_high)
+{
   // create lcd object
   LiquidCrystal_Test lcd(rs, enable, d4, d5, d6, d7);
-  
+
   // assert startup no cursor is set
   assertEqual(false, lcd.isCursor());
 


### PR DESCRIPTION
I did all of the testing under unittest(cursor_high). There was another unittest(noCursor_high), however I followed similar to the other unittest for blink having a single testing function despite it also having a blink/noBlink. looks a little more uniform.